### PR TITLE
Radvel setup file updates (HD114783, HD95735)

### DIFF
--- a/all_fits/HD_114783/fits/HD114783_radvel.py
+++ b/all_fits/HD_114783/fits/HD114783_radvel.py
@@ -1,11 +1,13 @@
 import pandas as pd
 import numpy as np
 import radvel
+import os
+
 
 # Define global planetary system and dataset parameters
-starname = "HD95735"
+starname = "HD114783"
 nplanets = 2  # number of planets in the system
-instnames = ["SOPHIE", "Hamilton", "HIRES-pre", "HIRES-post", "APF"]
+instnames = ["HARPS-pre", "HARPS-post", "HIRES-pre", "HIRES-post"]
 ntels = len(instnames)  # number of instruments with unique velocity zero-points
 fitting_basis = "per tc secosw sesinw k"  # Fitting basis, see radvel.basis.BASIS_NAMES for available basis names
 bjd0 = 2450000.0
@@ -16,19 +18,18 @@ anybasis_params = radvel.Parameters(
     nplanets, basis="per tp e w k"
 )  # initialize Parameters object
 
-anybasis_params["per1"] = radvel.Parameter(value=12.9532)  # period of 1st planet
-anybasis_params["tp1"] = radvel.Parameter(value=
+anybasis_params["per1"] = radvel.Parameter(value=493.7)  # period of 1st planet
+anybasis_params["tp1"] = radvel.Parameter(value=2453806)
 )  # time of periastron of 1st planet
-anybasis_params["e1"] = radvel.Parameter(value=0.22)  # eccentricity of 'per tp secosw sesinw k'1st planet
-anybasis_params["w1"] = radvel.Parameter(value=
-)  # argument of periastron of the star's orbit for 1st planet
-anybasis_params["k1"] = radvel.Parameter(value=1.59)  # velocity semi-amplitude for 1st planet
+anybasis_params["e1"] = radvel.Parameter(value=0.144)  # eccentricity of 'per tp secosw sesinw k'1st planet
+anybasis_params["w1"] = radvel.Parameter(value=86 * (np.pi/180))  # argument of periastron of the star's orbit for 1st planet
+anybasis_params["k1"] = radvel.Parameter(value=31.9)  # velocity semi-amplitude for 1st planet
 
-anybasis_params["per2"] = radvel.Parameter(value=3190)  # period of 2nd planet
-anybasis_params["tp2"] = radvel.Parameter(value=2456792.79)  # time of periastron of 2nd planet
-anybasis_params["e2"] = radvel.Parameter(value=0.14)  # eccentricity of 'per tp secosw sesinw k' 2nd planet
-anybasis_params["w2"] = radvel.Parameter(value=0.1) # RAD (?) # argument of periastron of the star's orbit for 2nd planet
-anybasis_params["k2"] = radvel.Parameter(value=1.56)  # velocity semi-amplitude for 2nd planet
+anybasis_params["per2"] = radvel.Parameter(value=4319)  # period of 2nd planet
+anybasis_params["tp2"] = radvel.Parameter(value=2458112)  # time of periastron of 2nd planet
+anybasis_params["e2"] = radvel.Parameter(value=0)  # eccentricity of 'per tp secosw sesinw k' 2nd planet
+anybasis_params["w2"] = radvel.Parameter(value=6.5 * (np.pi/180))  # argument of periastron of the star's orbit for 2nd planet
+anybasis_params["k2"] = radvel.Parameter(value=9.21)  # velocity semi-amplitude for 2nd planet
 
 
 ####################################
@@ -39,17 +40,17 @@ anybasis_params["k2"] = radvel.Parameter(value=1.56)  # velocity semi-amplitude 
 anybasis_params["dvdt"] = radvel.Parameter(value=0.0)  # slope
 anybasis_params["curv"] = radvel.Parameter(value=0.0)  # curvature
 
-anybasis_params["gamma_SOPHIE"] = radvel.Parameter(-84283.79)
-anybasis_params["gamma_Hamilton"] = radvel.Parameter(-3.64)
-anybasis_params["gamma_HIRES-pre"] = radvel.Parameter(2.09)
-anybasis_params["gamma_HIRES-post"] = radvel.Parameter(-0.93)
-anybasis_params["gamma_APF"] = radvel.Parameter(-1.46)
+anybasis_params["gamma_HIRES-pre"] = radvel.Parameter(-10.62)
+anybasis_params["gamma_HIRES-post"] = radvel.Parameter(-1.9)
+anybasis_params['gamma_HARPS-pre'] = radvel.Parameter(-3.23)
+anybasis_params['gamma_HARPS-post'] = radvel.Parameter(4.74)
 
-anybasis_params["jit_SOPHIE"] = radvel.Parameter(value=5)
-anybasis_params["jit_Hamilton"] = radvel.Parameter(value=5)
+
 anybasis_params["jit_HIRES-pre"] = radvel.Parameter(value=5)
 anybasis_params["jit_HIRES-post"] = radvel.Parameter(value=5)
-anybasis_params["jit_APF"] = radvel.Parameter(value=5)
+anybasis_params['jit_HARPS-pre'] = radvel.Parameter(value=5)
+anybasis_params['jit_HARPS-post'] = radvel.Parameter(value=5)
+
 
 #######################################
 
@@ -62,9 +63,10 @@ params["curv"].vary = False
 # Load radial velocity data, in this example the data is contained in an hdf file,
 # the resulting dataframe or must have 'time', 'mnvel', 'errvel', and 'tel' keys
 # the velocities are expected to be in m/s
+
 this_dir = os.path.dirname(__file__)
 parent_dir = os.path.dirname(this_dir)  # assumes the data dir and fits dir are in same parent dir
-path = os.path.join(parent_dir, "data", "HD95735_rv_combined_binned.txt")
+path = os.path.join(parent_dir, "data", "HD114783_rv_combined_binned.txt")
 
 data = pd.read_csv(
     path,
@@ -80,11 +82,10 @@ data = pd.read_csv(
 priors = [
     radvel.prior.EccentricityPrior(nplanets),  # Keeps eccentricity < 1
     radvel.prior.PositiveKPrior(nplanets),  # Keeps K > 0
-    radvel.prior.HardBounds("jit_SOPHIE", 0.0, 10.0),
-    radvel.prior.HardBounds("jit_Hamilton", 0.0, 10.0),
     radvel.prior.HardBounds("jit_HIRES-pre", 0.0, 10.0),
     radvel.prior.HardBounds("jit_HIRES-post", 0.0, 10.0),
-    radvel.prior.HardBounds("jit_APF", 0.0, 10.0)
+    radvel.prior.HardBounds('jit_HARPS-pre', 0.0, 10.0),
+    radvel.prior.HardBounds('jit_HARPS-post', 0.0, 10.0)
 ]
 
 # abscissa for slope and curvature terms (should be near mid-point of time baseline)
@@ -93,4 +94,4 @@ time_base = np.mean([np.min(data.time), np.max(data.time)])
 
 # optional argument that can contain stellar mass in solar units (mstar) and
 # uncertainty (mstar_err). If not set, mstar will be set to nan.
-stellar = dict(mstar=0.386, mstar_err=0.039)  # numbers from Diaz et al. 2019
+stellar = dict(mstar=0.853, mstar_err=0.034)  # numbers from Wittenmyer et al. 2009

--- a/all_fits/HD_114783/fits/README.md
+++ b/all_fits/HD_114783/fits/README.md
@@ -1,0 +1,5 @@
+HD 114783 b orbital params from: Vogt et al. 2002 https://arxiv.org/abs/astro-ph/0110378
+
+HD 114783 c orbital params from: Bryan et al. 2016 https://iopscience.iop.org/article/10.3847/0004-637X/821/2/89/pdf
+
+HD 114783 stellar mass from: Wittenmyer 2009 https://iopscience.iop.org/article/10.1088/0067-0049/182/1/97/pdf

--- a/all_fits/HD_95735/fits/README.md
+++ b/all_fits/HD_95735/fits/README.md
@@ -1,2 +1,5 @@
-HD 95735 b orbital params come from: https://www.aanda.org/articles/aa/pdf/2019/05/aa35019-19.pdf
-HD 95735 c params come from: https://iopscience.iop.org/article/10.3847/1538-4365/abe23c/meta#apjsabe23cf6
+HD 95735 b orbital params come from: Diaz et al. 2019 https://www.aanda.org/articles/aa/pdf/2019/05/aa35019-19.pdf
+
+HD 95735 c orbital params come from: Rosenthal at al. 2021 https://iopscience.iop.org/article/10.3847/1538-4365/abe23c/meta#apjsabe23cf6
+
+HD 95735 stellar mass comes from: Diaz et al. 2019 https://www.aanda.org/articles/aa/pdf/2019/05/aa35019-19.pdf


### PR DESCRIPTION
radvel fitting param updates (gamma, jit, and initial parameters) for HD114783 and HD95735. populated the gamma param for all instruments with the mean RV measurement with that instrument and populated the jitter param for each instrument with 5. also included initial orbital params for HD114783.